### PR TITLE
Add: auto-update tag using the desktop-snaps action

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -1,0 +1,21 @@
+name: Push new tag update to stable branch
+
+on:
+  schedule:
+    # Daily for now
+    - cron: '9 7 * * *'
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  update-snapcraft-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+      - name: Run desktop-snaps action
+        uses: ubuntu/desktop-snaps@stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,9 @@ confinement: strict
 
 parts:
   ustreamer:
+# ext:updatesnap
+#   version-format: "v%M.%m"
+# endext
     source: https://github.com/pikvm/ustreamer.git
     source-type: git
     source-depth: 1


### PR DESCRIPTION
A workflow for auto-updating the tag version pulling from upstream. The procedure is described in this [blog post](https://ubuntu.com/blog/improving-snap-maintenance-with-automation).